### PR TITLE
Fixed fatal bug where model failed to save

### DIFF
--- a/scripts/train_with_rm.py
+++ b/scripts/train_with_rm.py
@@ -572,7 +572,7 @@ def main(_):
                 # make sure we did an optimization step at the end of the inner epoch
                 assert accelerator.sync_gradients
 
-            if epoch!=0 and (epoch+1) % config.save_freq == 0 and accelerator.is_main_process:
+            if epoch!=0 and (epoch+1) % config.save_freq == 0:
                 accelerator.save_state()
 
 


### PR DESCRIPTION
accelerator.is_main_process() leads to forever waiting and cause saving failure! This method should be called by all processes!